### PR TITLE
Adding user-agent string

### DIFF
--- a/cl-honeycomb.cl
+++ b/cl-honeycomb.cl
@@ -326,7 +326,8 @@
 
 (defun do-post-span-hierarchy-to-honeycomb (span)
   (let ((url (util.string:string+ "https://api.honeycomb.io/1/batch/" (span-dataset span)))
-        (headers `(("X-Honeycomb-Team" . ,(span-api-key span))))
+        (headers `(("X-Honeycomb-Team" . ,(span-api-key span))
+                   ("User-Agent" . "cl-honeycomb")))
         (spans-todo (list span)))
     (loop while spans-todo
         do (let ((body (with-output-to-string (*standard-output*)


### PR DESCRIPTION
The Honeycomb-built libhoney SDKs include a User-Agent string to identify themselves to the endpoint to which they're sending traffic. This is most useful to Honeycomb (for understanding incoming traffic), so this PR is a bit selfish. Here's where that's set in the [Go](https://github.com/honeycombio/libhoney-go/blob/master/transmission/transmission.go#L325-L328) and [Ruby](https://github.com/honeycombio/libhoney-go/blob/master/transmission/transmission.go#L325-L328) SDKs (each assignment is used just a few lines below). 